### PR TITLE
Improvement/qdrant update version

### DIFF
--- a/agora/retrieval.py
+++ b/agora/retrieval.py
@@ -49,13 +49,14 @@ def main():
     client = QdrantClient(url=args.qdrant_url, api_key=args.qdrant_api_key or None)
     flt = Filter(must=[FieldCondition(key="source", match=MatchValue(value="utilitr"))])
 
-    hits = client.search(
+    response = client.query_points(
         collection_name=args.collection,
-        query_vector=vec,
+        query=vec,
         query_filter=flt,
         limit=args.top_k,
         with_payload=True,
     )
+    hits = response.points
 
     print(f"\nQuery: {query}\nTop {len(hits)} results:\n")
     for i, h in enumerate(hits, 1):

--- a/agora/vectorstores/qdrant_store.py
+++ b/agora/vectorstores/qdrant_store.py
@@ -108,12 +108,12 @@ def search_dense(
     flt = None
     if source:
         flt = Filter(must=[FieldCondition(key="source", match=MatchValue(value=source))])
-    hits = client.search(
+    response = client.query_points(
         collection_name=collection,
-        query_vector=query_vec,
+        query=query_vec,
         limit=top_k,
         with_payload=True,
         with_vectors=False,
         query_filter=flt,
     )
-    return hits
+    return response.points

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ description = "RAG ingestion CLI for CanaR"
 readme = "README.md"
 
 dependencies = [
-  "qdrant-client>=1.9.0",
+  "qdrant-client>=1.10.0",
   "markdown-it-py>=3.0.0",
   "PyYAML>=6.0.1",
   "numpy>=1.26.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-  qdrant-client>=1.9.0
+  qdrant-client>=1.10.0
   markdown-it-py>=3.0.0
   PyYAML>=6.0.1
   numpy>=1.26.0


### PR DESCRIPTION
## Summary
Update of the qdrant version to be from 1.10

Closes #

## Changes
- [ agora/retrieval.py]  change the method client.search for client.query_points
- [ agora/vectorstores/qdrant_store.py]   change the method client.search for client.query_points
- [pyproject.toml and requirements.txt] update for 1.10 qdrant minimal

## How to test
Run normally an ingestion as the readme.md explains
